### PR TITLE
Added support for generic JMAP 2-step authentication procedure (issue #8)

### DIFF
--- a/lib/client/Client.js
+++ b/lib/client/Client.js
@@ -90,11 +90,57 @@ export default class Client {
   }
 
   /**
+   * Implement the 2-step JMAP authentication protocol.<br />
+   * This method abstract the two authentication steps:
+   *
+   * 1. query the JMAP server to get a continuation token
+   * 2. query the JMAP server with the continuation token (and password), to get the final accessToken.
+   *
+   * @param username {String} The username to authenticate with
+   * @param deviceName {String} A unique device name
+   * @param continuationCallback {Function} A function that takes an {@link AuthContinuation}
+   *   object as argument, and should return a promise, that will eventually resolve with an
+   *   object denoting the chosen authentication method and the optional password (if method == password).
+   *
+   * @return {Promise} A {@link Promise} that will eventually be resovled with a {@link AuthAccess} object
+   */
+  authenticate(username, deviceName, continuationCallback) {
+    var authContinuation;
+    return this.transport
+      .post(this.authenticationUrl, this._defaultNonAuthenticatedHeaders(), {
+        username: username,
+        deviceName: deviceName,
+        clientName: Constants.CLIENT_NAME,
+        clientVersion: Constants.VERSION
+      })
+      .then((data) => {
+        authContinuation = new AuthContinuation(data);
+        return authContinuation;
+      })
+      .then((authContinuation) => continuationCallback(authContinuation))
+      .then((continueData) => {
+        if (authContinuation.methods.indexOf(continueData.method) < 0) {
+          throw new Error('The "' + continueData.method + '" authentication protocol is not supported by the server.');
+        }
+        let param = {
+          token: authContinuation.continuationToken,
+          method: continueData.method,
+        };
+        if (continueData.password) {
+          param.password = continueData.password;
+        }
+        return this.transport
+          .post(this.authenticationUrl, this._defaultNonAuthenticatedHeaders(), param);
+      })
+      .then((data) => new AuthAccess(data));
+  }
+
+  /**
    * Implement the JMAP external authentication protocol.<br />
    * This method abstract the two authentication steps:
    *
    * 1. query the JMAP server to get a continuation token
-   * 2. query the JMAP server with the authentication token, to get the final accessToken.
+   * 2. query the JMAP server with the continuation token, to get the final accessToken.
    *
    * <br />
    * Between those two steps, a user provided function wil be called to handle the external
@@ -108,35 +154,36 @@ export default class Client {
    *
    * @param username {String} The username of the user to authenticate.
    * @param deviceName {String} A unique device name
-   * @param continuationCallback {Function} A function that takes an {@link AuthContinuation} object as argument, and should return a promise, that will resolve with the continuation token.
+   * @param continuationCallback {Function} A function that takes an {@link AuthContinuation} object as argument, and should return a promise, that will resolve once the external authentication is complete.
    *
-   * @return {Client} This Client instance.
+   * @return {Promise} A {@link Promise} that will eventually be resovled with a {@link AuthAccess} object
    */
-
   authExternal(username, deviceName, continuationCallback) {
-    return this.transport
-      .post(this.authenticationUrl, this._defaultNonAuthenticatedHeaders(), {
-        username: username,
-        deviceName: deviceName,
-        clientName: 'jmap-client (https://github.com/linagora/jmap-client)',
-        clientVersion: Constants.VERSION
-      })
-      .then((data) => {
-        var authContinuation = new AuthContinuation(data);
-        if (authContinuation.methods.indexOf('external') < 0) {
-          throw new Error('The "external" authentication protocol is not supported by the server.');
-        }
-        return authContinuation;
-      })
-      .then((authContinuation) => continuationCallback(authContinuation))
-      .then((continuationToken) => {
-        return this.transport
-          .post(this.authenticationUrl, this._defaultNonAuthenticatedHeaders(), {
-            token: continuationToken,
-            method: 'external'
-          });
-      })
-      .then((data) => new AuthAccess(data));
+    return this.authenticate(username, deviceName, function(authContinuation) {
+      // wrap the continuationCallback to resolve with method:'external'
+      return continuationCallback(authContinuation).then(() => {
+        return { method: 'external' };
+      });
+    });
+  }
+
+  /**
+   * Implement the JMAP password authentication protocol.<br />
+   * This method abstract the two authentication steps:
+   *
+   * 1. query the JMAP server to get a continuation token
+   * 2. query the JMAP server with the continuation token and the password, to get the final accessToken.
+   *
+   * @param username {String} The username of the user to authenticate
+   * @param password {String} The password of the user to authenticate
+   * @param deviceName {String} A unique device name
+   *
+   * @return {Promise} A {@link Promise} that will eventually be resovled with a {@link AuthAccess} object
+   */
+  authPassword(username, password, deviceName) {
+    return this.authenticate(username, deviceName, function(authContinuation) {
+      return { method: 'password', password: password };
+    });
   }
 
   /**

--- a/lib/utils/Constants.js
+++ b/lib/utils/Constants.js
@@ -8,5 +8,6 @@
  * @module Constants
  */
 export default {
-  VERSION: '__VERSION__'
+  VERSION: '__VERSION__',
+  CLIENT_NAME: 'jmap-client (https://github.com/linagora/jmap-client)'
 };


### PR DESCRIPTION
A new method `Client.authenticate()` implements the JMAP authentication process where the server is first queries for available authentication methods and a callback function can proceed by providing the method to use and additional parameters such the user password.

The change also includes a refactoring of the already existing `authExternal` method which now delegates to the new generic functions. An additional short-hand method `authPassword`has been added for convenience reasons.

All three authentication functions are covered by tests.

I hope I got the coding guidelines right. If not, please commend inline and let me learn. 
