### PR TITLE
Enforce coding style rules (issue #9)

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,10 +1,16 @@
 {
-	"preset": "airbnb",
-	"requirePaddingNewLinesAfterBlocks": null,
-	"requireTrailingComma": null,
-	"disallowMultipleVarDecl": null,
-	"requirePaddingNewLinesBeforeLineComments": null,
-	"safeContextKeyword": ["self"],
-	"requireCamelCaseOrUpperCaseIdentifiers": null
+  "preset": "airbnb",
+  "requirePaddingNewLinesAfterBlocks": null,
+  "requirePaddingNewLineAfterVariableDeclaration": true,
+  "requirePaddingNewlinesBeforeKeywords": ["return"],
+  "requireCurlyBraces": ["if", "else", "for", "while", "do", "try", "catch", "switch"],
+  "requireTrailingComma": null,
+  "requirePaddingNewLinesBeforeLineComments": null,
+  "requireCamelCaseOrUpperCaseIdentifiers": null,
+  "requirePaddingNewLinesAfterUseStrict": true,
+  "disallowMultipleVarDecl": null,
+  "disallowTrailingWhitespace": true,
+  "validateIndentation": 2,
+  "safeContextKeyword": ["self"]
 }
 

--- a/.jshintrc
+++ b/.jshintrc
@@ -13,7 +13,7 @@
   "quotmark": "single",
   "regexp": true,
   "undef": true,
-  "unused": false,
+  "unused": "vars",
   "strict": true,
   "trailing": true,
   "smarttabs": true,

--- a/lib/client/Client.js
+++ b/lib/client/Client.js
@@ -43,6 +43,7 @@ export default class Client {
    */
   withAuthenticationUrl(url) {
     this.authenticationUrl = url;
+
     return this;
   }
 
@@ -58,6 +59,7 @@ export default class Client {
    */
   withAuthenticationToken(token) {
     this.authToken = token;
+
     return this;
   }
 
@@ -72,6 +74,7 @@ export default class Client {
    */
   withAPIUrl(url) {
     this.apiUrl = url;
+
     return this;
   }
 
@@ -86,6 +89,7 @@ export default class Client {
    */
   withDownloadUrl(url) {
     this.downloadUrl = url;
+
     return this;
   }
 
@@ -123,9 +127,11 @@ export default class Client {
       })
       .then((data) => {
         var authContinuation = new AuthContinuation(data);
+
         if (authContinuation.methods.indexOf('external') < 0) {
           throw new Error('The "external" authentication protocol is not supported by the server.');
         }
+
         return authContinuation;
       })
       .then((authContinuation) => continuationCallback(authContinuation))
@@ -263,6 +269,7 @@ export default class Client {
     Utils.assertRequiredParameterHasType(message, 'message', OutboundMessage);
 
     var clientId = this._generateClientId();
+
     return this
       .getMailboxWithRole(MailboxRole.DRAFTS)
       .then(mailbox => {
@@ -278,6 +285,7 @@ export default class Client {
         if (!response.created[clientId]) {
           throw new Error('Failed to save the message as draft, clientId: ' + clientId + ', message: ' + (response.notCreated[clientId] || 'none'));
         }
+
         return new CreateMessageAck(this, response.created[clientId]);
       });
   }

--- a/lib/models/MailboxRole.js
+++ b/lib/models/MailboxRole.js
@@ -1,7 +1,5 @@
 'use strict';
 
-import Utils from '../utils/Utils.js';
-
 class MailboxRole {
   /**
    * The MailboxRole class is simply a holder for predefined JMAP mailbox roles.<br />

--- a/lib/models/Message.js
+++ b/lib/models/Message.js
@@ -3,7 +3,6 @@
 import Model from './Model.js';
 import EMailer from './EMailer.js';
 import Utils from '../utils/Utils.js';
-import MailboxRole from './MailboxRole.js';
 import Attachment from './Attachment.js';
 
 export default class Message extends Model {

--- a/lib/utils/JSONBuilder.js
+++ b/lib/utils/JSONBuilder.js
@@ -48,6 +48,7 @@ export default class JSONBuilder {
     if (Utils.isDefined(value)) {
       this.append(name, value);
     }
+
     return this;
   }
 
@@ -66,6 +67,7 @@ export default class JSONBuilder {
         this.append(name, value.map(item => item.toJSONObject ? item.toJSONObject() : item));
       }
     }
+
     return this;
   }
 

--- a/test/common/Client.js
+++ b/test/common/Client.js
@@ -1070,6 +1070,7 @@ describe('The Client class', function() {
           expect(data.clientName).to.have.length.above(0);
           expect(data.clientVersion).to.have.length.above(0);
           done();
+
           return q.Promise(function() {});
         }
       })
@@ -1108,16 +1109,19 @@ describe('The Client class', function() {
         expect(authContinuation.continuationToken).to.equal('continuationToken1');
         expect(authContinuation.methods).to.deep.equal(['password', 'external']);
         done();
+
         return q.reject();
       });
     });
 
     it('should request the accessToken', function(done) {
       var calls =  0;
+
       new jmap.Client({
         post: function(url, headers, data) {
           if (calls === 0) {
             calls++;
+
             return q({
               continuationToken: 'continuationToken1',
               methods: ['password', 'external']
@@ -1126,6 +1130,7 @@ describe('The Client class', function() {
             expect(data.token).to.equal('continuationToken1');
             expect(data.method).to.equal('external');
             done();
+
             return q();
           }
         }
@@ -1185,9 +1190,11 @@ describe('The Client class', function() {
 
     it('should call getMailboxWithRole to find the draft mailbox id', function(done) {
       var client = defaultClient();
+
       client.getMailboxWithRole = function(role) {
         expect(role).to.deep.equal(new jmap.MailboxRole('drafts'));
         done();
+
         return q.reject();
       };
 

--- a/test/common/models/AuthAccess.js
+++ b/test/common/models/AuthAccess.js
@@ -18,6 +18,7 @@ describe('The AuthAccess class', function() {
         upload: 'http://localhost:8899/upload',
         download: 'http://localhost:8899/download'
       };
+
       expect(function() {
         new jmap.AuthAccess(payload);
       }).to.throw(Error);
@@ -30,6 +31,7 @@ describe('The AuthAccess class', function() {
         upload: 'http://localhost:8899/upload',
         download: 'http://localhost:8899/download'
       };
+
       expect(function() {
         new jmap.AuthAccess(payload);
       }).to.throw(Error);
@@ -42,6 +44,7 @@ describe('The AuthAccess class', function() {
         upload: 'http://localhost:8899/upload',
         download: 'http://localhost:8899/download'
       };
+
       expect(function() {
         new jmap.AuthAccess(payload);
       }).to.throw(Error);
@@ -54,6 +57,7 @@ describe('The AuthAccess class', function() {
         eventSource: 'http://localhost:8899/upload',
         download: 'http://localhost:8899/download'
       };
+
       expect(function() {
         new jmap.AuthAccess(payload);
       }).to.throw(Error);
@@ -66,6 +70,7 @@ describe('The AuthAccess class', function() {
         upload: 'http://localhost:8899/upload',
         eventSource: 'http://localhost:8899/download'
       };
+
       expect(function() {
         new jmap.AuthAccess(payload);
       }).to.throw(Error);
@@ -81,6 +86,7 @@ describe('The AuthAccess class', function() {
       };
 
       var authToken = new jmap.AuthAccess(payload);
+
       expect(authToken.accessToken).to.equal(payload.accessToken);
       expect(authToken.api).to.equal(payload.api);
       expect(authToken.eventSource).to.equal(payload.eventSource);

--- a/test/common/models/AuthContinuation.js
+++ b/test/common/models/AuthContinuation.js
@@ -14,6 +14,7 @@ describe('The AuthContinuation class', function() {
     it('should throw if payload.continuationToken parameter is not defined', function() {
       expect(function() {
         var payload = {methods: []};
+
         new jmap.AuthContinuation(payload);
       }).to.throw(Error);
     });
@@ -21,6 +22,7 @@ describe('The AuthContinuation class', function() {
     it('should throw if payload.methods parameter is not defined', function() {
       expect(function() {
         var payload = {continuationToken: 'continuationToken1'};
+
         new jmap.AuthContinuation(payload);
       }).to.throw(Error);
     });
@@ -28,6 +30,7 @@ describe('The AuthContinuation class', function() {
     it('should throw if payload.methods parameter is not an array', function() {
       expect(function() {
         var payload = {continuationToken: 'continuationToken1', methods: 'password'};
+
         new jmap.AuthContinuation(payload);
       }).to.throw(Error);
     });
@@ -35,6 +38,7 @@ describe('The AuthContinuation class', function() {
     it('should expose continuationToken and methods properties', function() {
       var payload = {continuationToken: 'continuationToken1', methods: ['password', 'external']};
       var authContinuation = new jmap.AuthContinuation(payload);
+
       expect(authContinuation.continuationToken).to.equal(payload.continuationToken);
       expect(authContinuation.methods).to.deep.equal(payload.methods);
     });

--- a/test/common/models/OutboundMessage.js
+++ b/test/common/models/OutboundMessage.js
@@ -28,11 +28,13 @@ describe('The OutboundMessage class', function() {
 
     it('should use default values for fields if opts is not defined', function() {
       var message = new jmap.OutboundMessage({});
+
       expectDefaultValues(message);
     });
 
     it('should use default values for fields if opts is empty', function() {
       var message = new jmap.OutboundMessage({}, {});
+
       expectDefaultValues(message);
     });
 

--- a/test/common/utils/Utils.js
+++ b/test/common/utils/Utils.js
@@ -93,6 +93,7 @@ describe('The Utils class', function() {
     it('should throw an Error if the parameter is undefined', function() {
       expect(function() {
         var param;
+
         jmap.Utils.assertRequiredParameterIsObject(param, 'parameter');
       }).to.throw(Error);
     });
@@ -127,6 +128,7 @@ describe('The Utils class', function() {
 
     it('should not throw an Error if the parameter has the expected type for custom type', function() {
       var val = new TestType();
+
       expect(jmap.Utils.assertRequiredParameterHasType(val, 'name', TestType)).to.equal(val);
     });
 


### PR DESCRIPTION
# New rules:

> require newline after variable declaration
> require newline before return
> require newline after use strict
> require curly braces for: "if", "else", "for", "while", "do", "try", "catch", "switch"
> prevent trailing whitespaces
> prevent unused variables
> validate indentation (\* 2 spaces)
