### PR TITLE
Extend JMAP auth continue routine to support multiple iterations (#12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [master]
 ### Added
+- Support multiple auth continue iterations #12
+- Add Client.promiseProvider
 
 ## [0.0.11] - 2016-02-01
 ### Added

--- a/lib/client/Client.js
+++ b/lib/client/Client.js
@@ -30,8 +30,9 @@ export default class Client {
   constructor(transport, promiseProvider) {
     Utils.assertRequiredParameterIsPresent(transport, 'transport');
 
+    this.promiseProvider = promiseProvider || new ES6PromiseProvider();
     this.transport = transport;
-    this.transport.promiseProvider = promiseProvider || new ES6PromiseProvider();
+    this.transport.promiseProvider = this.promiseProvider;
   }
 
   /**
@@ -111,8 +112,6 @@ export default class Client {
    * @return {Promise} A {@link Promise} that will eventually be resovled with a {@link AuthAccess} object
    */
   authenticate(username, deviceName, continuationCallback) {
-    var authContinuation;
-
     return this.transport
       .post(this.authenticationUrl, this._defaultNonAuthenticatedHeaders(), {
         username: username,
@@ -120,29 +119,51 @@ export default class Client {
         clientName: Constants.CLIENT_NAME,
         clientVersion: Constants.VERSION
       })
-      .then(data => {
-        authContinuation = new AuthContinuation(data);
+      .then(data => this._authenticateResponse(data, continuationCallback));
+  }
 
-        return authContinuation;
-      })
-      .then(authContinuation => continuationCallback(authContinuation))
-      .then(continueData => {
-        if (authContinuation.methods.indexOf(continueData.method) < 0) {
-          throw new Error('The "' + continueData.method + '" authentication protocol is not supported by the server.');
-        }
-        let param = {
-          token: authContinuation.continuationToken,
-          method: continueData.method
-        };
+  /**
+   * Sub-routine handling JMAP server responses on authentication requests
+   *
+   * Depending on the server's response, this either (recursively) executes the second
+   * authentication step by calling the provided continuationCallback or resolves on
+   * successfully completed authentication.
+   *
+   * @param data {Object} The JMAP response data
+   * @param continuationCallback {Function} The callback function initially passed to the authenticate() method
+   *
+   * @return {Promise} A {@link Promise} that will eventually be resovled with a {@link AuthAccess} object
+   */
+  _authenticateResponse(data, continuationCallback) {
+    if (data.continuationToken && data.accessToken === undefined) {
+      // got an AuthContinuation response
+      var authContinuation = new AuthContinuation(data);
 
-        if (continueData.password) {
-          param.password = continueData.password;
-        }
+      return continuationCallback(authContinuation)
+        .then(continueData => {
+          if (authContinuation.methods.indexOf(continueData.method) < 0) {
+            throw new Error('The "' + continueData.method + '" authentication protocol is not supported by the server.');
+          }
+          let param = {
+            token: authContinuation.continuationToken,
+            method: continueData.method
+          };
 
-        return this.transport
-          .post(this.authenticationUrl, this._defaultNonAuthenticatedHeaders(), param);
-      })
-      .then(data => new AuthAccess(data));
+          if (continueData.password) {
+            param.password = continueData.password;
+          }
+
+          return this.transport
+            .post(this.authenticationUrl, this._defaultNonAuthenticatedHeaders(), param);
+        })
+        .then(resp => this._authenticateResponse(resp, continuationCallback));
+    } else if (data.accessToken && data.continuationToken === undefined) {
+      // got auth access response
+      return new AuthAccess(data);
+    } else {
+      // got unknown response data
+      throw new Error('Unexpected response on authorization request');
+    }
   }
 
   /**
@@ -192,8 +213,10 @@ export default class Client {
    */
   authPassword(username, password, deviceName) {
     return this.authenticate(username, deviceName, function() {
-      return { method: 'password', password: password };
-    });
+      return this.promiseProvider.newPromise(function(resolve, reject) {
+        resolve({ method: 'password', password: password });
+      });
+    }.bind(this));
   }
 
   /**


### PR DESCRIPTION
Added subroutine `_authenticateResponse()` which is called recursively as long as the server responds with a `continuationToken` prompting for a password.

The `continuationCallback` will also be called multiple times whenever the server responds with a `continuationToken`. The promise returned by `authenticate()` will only resolve after all continuation steps  have passed.
