### PR TITLE
Adapt AuthAccess model to new JMAP endpoint properties (issue #38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [master]
+### Fixed
+- New/changed JMAP endpoint properties in AuthAcces. #38
 
 ## [0.0.14] - 2016-05-19
 ### Added

--- a/lib/models/AuthAccess.js
+++ b/lib/models/AuthAccess.js
@@ -13,12 +13,9 @@ export default class AuthAccess {
 
   constructor(payload) {
     Utils.assertRequiredParameterIsPresent(payload, 'payload');
-    Utils.assertRequiredParameterIsPresent(payload.username, 'username');
-    Utils.assertRequiredParameterIsPresent(payload.accessToken, 'accessToken');
-    Utils.assertRequiredParameterIsPresent(payload.apiUrl, 'apiUrl');
-    Utils.assertRequiredParameterIsPresent(payload.eventSourceUrl, 'eventSourceUrl');
-    Utils.assertRequiredParameterIsPresent(payload.uploadUrl, 'uploadUrl');
-    Utils.assertRequiredParameterIsPresent(payload.downloadUrl, 'downloadUrl');
+    ['username', 'accessToken', 'apiUrl', 'eventSourceUrl', 'uploadUrl', 'downloadUrl'].forEach((property) => {
+      Utils.assertRequiredParameterIsPresent(payload[property], property);
+    });
 
     this.username = payload.username;
     this.versions = payload.versions || [];

--- a/lib/models/AuthAccess.js
+++ b/lib/models/AuthAccess.js
@@ -13,16 +13,20 @@ export default class AuthAccess {
 
   constructor(payload) {
     Utils.assertRequiredParameterIsPresent(payload, 'payload');
+    Utils.assertRequiredParameterIsPresent(payload.username, 'username');
     Utils.assertRequiredParameterIsPresent(payload.accessToken, 'accessToken');
-    Utils.assertRequiredParameterIsPresent(payload.api, 'api');
-    Utils.assertRequiredParameterIsPresent(payload.eventSource, 'eventSource');
-    Utils.assertRequiredParameterIsPresent(payload.upload, 'upload');
-    Utils.assertRequiredParameterIsPresent(payload.download, 'download');
+    Utils.assertRequiredParameterIsPresent(payload.apiUrl, 'apiUrl');
+    Utils.assertRequiredParameterIsPresent(payload.eventSourceUrl, 'eventSourceUrl');
+    Utils.assertRequiredParameterIsPresent(payload.uploadUrl, 'uploadUrl');
+    Utils.assertRequiredParameterIsPresent(payload.downloadUrl, 'downloadUrl');
 
+    this.username = payload.username;
+    this.versions = payload.versions || [];
+    this.extensions = payload.extensions || {};
     this.accessToken = payload.accessToken;
-    this.api = payload.api;
-    this.eventSource = payload.eventSource;
-    this.upload = payload.upload;
-    this.download = payload.download;
+    this.apiUrl = payload.apiUrl;
+    this.eventSourceUrl = payload.eventSourceUrl;
+    this.uploadUrl = payload.uploadUrl;
+    this.downloadUrl = payload.downloadUrl;
   }
 }

--- a/test/common/Client.js
+++ b/test/common/Client.js
@@ -1646,11 +1646,14 @@ describe('The Client class', function() {
 
     it('should resolve with AuthAccess', function(done) {
       var authAccessResponse = {
+        username: 'user@domain.com',
+        versions: [1],
+        extensions: {},
         accessToken: 'accessToken1',
-        api: '/',
-        eventSource: '/es',
-        upload: '/upload',
-        download: '/download'
+        apiUrl: '/',
+        eventSourceUrl: '/es',
+        uploadUrl: '/upload',
+        downloadUrl: '/download'
       };
 
       new jmap.Client({
@@ -1677,11 +1680,14 @@ describe('The Client class', function() {
 
     it('should repeat authentication steps if server demands to', function(done) {
       var authAccessResponse = {
+        username: 'user@domain.com',
+        versions: [1],
+        extensions: {},
         accessToken: 'accessToken1',
-        api: '/',
-        eventSource: '/es',
-        upload: '/upload',
-        download: '/download'
+        apiUrl: '/',
+        eventSourceUrl: '/es',
+        uploadUrl: '/upload',
+        downloadUrl: '/download'
       };
 
       new jmap.Client({
@@ -1809,11 +1815,14 @@ describe('The Client class', function() {
 
     it('should give back a AuthAccess', function(done) {
       var authAccessResponse = {
+        username: 'user@domain.com',
+        versions: [1],
+        extensions: {},
         accessToken: 'accessToken1',
-        api: '/',
-        eventSource: '/es',
-        upload: '/upload',
-        download: '/download'
+        apiUrl: '/',
+        eventSourceUrl: '/es',
+        uploadUrl: '/upload',
+        downloadUrl: '/download'
       };
 
       new jmap.Client({
@@ -1862,11 +1871,14 @@ describe('The Client class', function() {
 
     it('should give back a AuthAccess', function(done) {
       var authAccessResponse = {
+        username: 'user@domain.com',
+        versions: [1],
+        extensions: {},
         accessToken: 'accessToken1',
-        api: '/',
-        eventSource: '/es',
-        upload: '/upload',
-        download: '/download'
+        apiUrl: '/',
+        eventSourceUrl: '/es',
+        uploadUrl: '/upload',
+        downloadUrl: '/download'
       };
 
       new jmap.Client({

--- a/test/common/models/AuthAccess.js
+++ b/test/common/models/AuthAccess.js
@@ -109,12 +109,9 @@ describe('The AuthAccess class', function() {
 
       var authToken = new jmap.AuthAccess(payload);
 
-      expect(authToken.username).to.equal(payload.username);
-      expect(authToken.accessToken).to.equal(payload.accessToken);
-      expect(authToken.apiUrl).to.equal(payload.apiUrl);
-      expect(authToken.eventSourceUrl).to.equal(payload.eventSourceUrl);
-      expect(authToken.downloadUrl).to.equal(payload.downloadUrl);
-      expect(authToken.uploadUrl).to.equal(payload.uploadUrl);
+      ['username', 'accessToken', 'apiUrl', 'eventSourceUrl', 'uploadUrl', 'downloadUrl'].forEach(function(property) {
+        expect(authToken[property]).to.equal(payload[property]);
+      });
     });
   });
 });

--- a/test/common/models/AuthAccess.js
+++ b/test/common/models/AuthAccess.js
@@ -13,10 +13,11 @@ describe('The AuthAccess class', function() {
 
     it('should throw if payload.accessToken parameter is not defined', function() {
       var payload = {
-        api: 'http://localhost:8899',
-        eventSource: 'http://localhost:8899/eventSource',
-        upload: 'http://localhost:8899/upload',
-        download: 'http://localhost:8899/download'
+        username: 'user',
+        apiUrl: 'http://localhost:8899',
+        eventSourceUrl: 'http://localhost:8899/eventSource',
+        uploadUrl: 'http://localhost:8899/upload',
+        downloadUrl: 'http://localhost:8899/download'
       };
 
       expect(function() {
@@ -26,10 +27,11 @@ describe('The AuthAccess class', function() {
 
     it('should throw if payload.api parameter is not defined', function() {
       var payload = {
+        username: 'user',
         accessToken: 'http://localhost:8899',
-        eventSource: 'http://localhost:8899/eventSource',
-        upload: 'http://localhost:8899/upload',
-        download: 'http://localhost:8899/download'
+        eventSourceUrl: 'http://localhost:8899/eventSource',
+        uploadUrl: 'http://localhost:8899/upload',
+        downloadUrl: 'http://localhost:8899/download'
       };
 
       expect(function() {
@@ -39,10 +41,11 @@ describe('The AuthAccess class', function() {
 
     it('should throw if payload.eventSource parameter is not defined', function() {
       var payload = {
+        username: 'user',
         accessToken: 'http://localhost:8899',
-        api: 'http://localhost:8899/eventSource',
-        upload: 'http://localhost:8899/upload',
-        download: 'http://localhost:8899/download'
+        apiUrl: 'http://localhost:8899/eventSource',
+        uploadUrl: 'http://localhost:8899/upload',
+        downloadUrl: 'http://localhost:8899/download'
       };
 
       expect(function() {
@@ -52,10 +55,11 @@ describe('The AuthAccess class', function() {
 
     it('should throw if payload.upload parameter is not defined', function() {
       var payload = {
+        username: 'user',
         accessToken: 'http://localhost:8899',
-        api: 'http://localhost:8899/eventSource',
-        eventSource: 'http://localhost:8899/upload',
-        download: 'http://localhost:8899/download'
+        apiUrl: 'http://localhost:8899/eventSource',
+        eventSourceUrl: 'http://localhost:8899/upload',
+        downloadUrl: 'http://localhost:8899/download'
       };
 
       expect(function() {
@@ -65,10 +69,11 @@ describe('The AuthAccess class', function() {
 
     it('should throw if payload.download parameter is not defined', function() {
       var payload = {
+        username: 'user',
         accessToken: 'http://localhost:8899',
-        api: 'http://localhost:8899/eventSource',
-        upload: 'http://localhost:8899/upload',
-        eventSource: 'http://localhost:8899/download'
+        apiUrl: 'http://localhost:8899/eventSource',
+        uploadUrl: 'http://localhost:8899/upload',
+        eventSourceUrl: 'http://localhost:8899/download'
       };
 
       expect(function() {
@@ -76,22 +81,40 @@ describe('The AuthAccess class', function() {
       }).to.throw(Error);
     });
 
-    it('should expose accessToken, api, eventSource, download and upload properties', function() {
+    it('should throw if payload.username parameter is not defined', function() {
       var payload = {
         accessToken: 'http://localhost:8899',
-        api: 'http://localhost:8899/eventSource',
-        eventSource: 'http://localhost:8899/eventSource',
-        upload: 'http://localhost:8899/upload',
-        download: 'http://localhost:8899/download'
+        apiUrl: 'http://localhost:8899/eventSource',
+        uploadUrl: 'http://localhost:8899/upload',
+        downloadUrl: 'http://localhost:8899/download',
+        eventSourceUrl: 'http://localhost:8899/download'
+      };
+
+      expect(function() {
+        new jmap.AuthAccess(payload);
+      }).to.throw(Error);
+    });
+
+    it('should expose username, accessToken, apiUrl, eventSourceUrl, downloadUrl and uploadUrl properties', function() {
+      var payload = {
+        username: 'user',
+        versions: [1],
+        extensions: { 'com.fastmail.message': [1] },
+        accessToken: 'http://localhost:8899',
+        apiUrl: 'http://localhost:8899/eventSource',
+        eventSourceUrl: 'http://localhost:8899/eventSource',
+        uploadUrl: 'http://localhost:8899/upload',
+        downloadUrl: 'http://localhost:8899/download'
       };
 
       var authToken = new jmap.AuthAccess(payload);
 
+      expect(authToken.username).to.equal(payload.username);
       expect(authToken.accessToken).to.equal(payload.accessToken);
-      expect(authToken.api).to.equal(payload.api);
-      expect(authToken.eventSource).to.equal(payload.eventSource);
-      expect(authToken.download).to.equal(payload.download);
-      expect(authToken.upload).to.equal(payload.upload);
+      expect(authToken.apiUrl).to.equal(payload.apiUrl);
+      expect(authToken.eventSourceUrl).to.equal(payload.eventSourceUrl);
+      expect(authToken.downloadUrl).to.equal(payload.downloadUrl);
+      expect(authToken.uploadUrl).to.equal(payload.uploadUrl);
     });
   });
 });


### PR DESCRIPTION
After recent updates in the the JMAP spec, the `AuthAccess` model has changed properties for the endpoint URLs and gained three more properties: username, versions, extensions.

This changeset updates the model to the current JMAP spec as well as all tests.
