### PR TITLE
Add Client.withAuthAccess() to set client properties from an authentication response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [master]
+### Added
+- Client.withAuthAccess
+
 ### Fixed
 - New/changed JMAP endpoint properties in AuthAcces. #38
 

--- a/lib/client/Client.js
+++ b/lib/client/Client.js
@@ -97,6 +97,26 @@ export default class Client {
   }
 
   /**
+   * Initializes the client with an {@link AuthAccess} model from an authentication response.<br />
+   * <br />
+   * The individual properties of the AuthAccess object will be copied into client properties.
+   *
+   * @param access {AuthAccess} The response object from an authenticate process.
+   *
+   * @return {Client} This Client instance.
+   */
+  withAuthAccess(access) {
+    Utils.assertRequiredParameterHasType(access, 'access', AuthAccess);
+
+    this.authToken = access.accessToken;
+    ['username', 'apiUrl', 'eventSourceUrl', 'uploadUrl', 'downloadUrl', 'versions', 'extensions'].forEach((property) => {
+      this[property] = access[property];
+    });
+
+    return this;
+  }
+
+  /**
    * Implement the 2-step JMAP authentication protocol.<br />
    * This method abstract the two authentication steps:
    *

--- a/test/common/Client.js
+++ b/test/common/Client.js
@@ -69,6 +69,36 @@ describe('The Client class', function() {
 
   });
 
+  describe('The withAuthAccess method', function() {
+
+    var authAccess = new jmap.AuthAccess({
+      username: 'user',
+      versions: [1],
+      extensions: { 'com.linagory.ext': [1] },
+      accessToken: 'accessToken1',
+      apiUrl: '/es',
+      eventSourceUrl: '/eventSource',
+      uploadUrl: '/upload',
+      downloadUrl: '/download'
+    });
+
+    it('should throw if access parameter is not an instance of AuthAccess', function() {
+      expect(function() {
+        defaultClient().withAuthAccess({});
+      }).to.throw(Error);
+    });
+
+    it('should store the AuthAccess properties', function() {
+      var client = defaultClient().withAuthAccess(authAccess);
+
+      expect(client.authToken).to.equal(authAccess.accessToken);
+      ['username', 'versions', 'extensions', 'apiUrl', 'eventSourceUrl', 'uploadUrl', 'downloadUrl'].forEach(function(property) {
+        expect(client[property]).to.equal(authAccess[property]);
+      });
+    });
+
+  });
+
   describe('The getAccounts method', function() {
 
     it('should post on the API url', function(done) {


### PR DESCRIPTION
This is a convenience method to initialize a `Client` instance with all properties from an authentication response in one go.

When doing JMAP authentication with the client's functions, you'll eventually get an `AuthAccess` instance. So why not passing that directly to the client again to set all the required properties for subsequent JMAP requests?
