### PR TITLE
Update auth-related functions and models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [master]
+### Added
+- The AuthMethod model
+
+### Changed
+- Data strcutures used during authentication procedure after changes to the JMAP spec
+- The AuthContinuation model
 
 ## [0.0.20] - 2016-08-22
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - The AuthMethod model
 
 ### Changed
-- Data strcutures used during authentication procedure after changes to the JMAP spec
+- Use the X-JMAP authentication scheme to construct the Authorization header. #44
+- Data structures used during authentication procedure after changes to the JMAP spec. #44
 - The AuthContinuation model
 
 ## [0.0.20] - 2016-08-22

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -135,7 +135,10 @@ module.exports = function(grunt) {
     browserify: {
       dist: {
         options: {
-          transform: ['browserify-versionify', 'babelify'],
+          transform: [
+            'browserify-versionify',
+            ['babelify', {plugins: ['object-assign']}]
+          ],
           browserifyOptions: {
             standalone: 'jmap'
           },

--- a/lib/API.js
+++ b/lib/API.js
@@ -65,6 +65,7 @@ export default {
   SetResponse: require('./models/SetResponse'),
   AuthAccess: require('./models/AuthAccess'),
   AuthContinuation: require('./models/AuthContinuation'),
+  AuthMethod: require('./models/AuthMethod'),
   Constants: require('./utils/Constants'),
   Attachment: require('./models/Attachment'),
   AccountCapabilities: require('./models/AccountCapabilities'),

--- a/lib/client/Client.js
+++ b/lib/client/Client.js
@@ -154,29 +154,29 @@ export default class Client {
    * @return {Promise} A {@link Promise} that will eventually be resovled with a {@link AuthAccess} object
    */
   _authenticateResponse(data, continuationCallback) {
-    if (data.continuationToken && data.accessToken === undefined) {
+    if (data.loginId && data.accessToken === undefined) {
       // got an AuthContinuation response
       var authContinuation = new AuthContinuation(data);
 
       return continuationCallback(authContinuation)
         .then(continueData => {
-          if (authContinuation.methods.indexOf(continueData.method) < 0) {
-            throw new Error('The "' + continueData.method + '" authentication protocol is not supported by the server.');
+          if (!authContinuation.supports(continueData.type)) {
+            throw new Error('The "' + continueData.type + '" authentication type is not supported by the server.');
           }
           let param = {
-            token: authContinuation.continuationToken,
-            method: continueData.method
+            loginId: authContinuation.loginId,
+            type: continueData.type
           };
 
-          if (continueData.password) {
-            param.password = continueData.password;
+          if (continueData.value) {
+            param.value = continueData.value;
           }
 
           return this.transport
             .post(this.authenticationUrl, this._defaultNonAuthenticatedHeaders(), param);
         })
         .then(resp => this._authenticateResponse(resp, continuationCallback));
-    } else if (data.accessToken && data.continuationToken === undefined) {
+    } else if (data.accessToken && data.loginId === undefined) {
       // got auth access response
       return new AuthAccess(data);
     } else {
@@ -212,7 +212,7 @@ export default class Client {
     return this.authenticate(username, deviceName, function(authContinuation) {
       // wrap the continuationCallback to resolve with method:'external'
       return continuationCallback(authContinuation).then(() => {
-        return { method: 'external' };
+        return { type: 'external' };
       });
     });
   }
@@ -233,7 +233,7 @@ export default class Client {
   authPassword(username, password, deviceName) {
     return this.authenticate(username, deviceName, function() {
       return this.promiseProvider.newPromise(function(resolve, reject) {
-        resolve({ method: 'password', password: password });
+        resolve({ type: 'password', value: password });
       });
     }.bind(this));
   }

--- a/lib/client/Client.js
+++ b/lib/client/Client.js
@@ -650,7 +650,7 @@ export default class Client {
     return {
       Accept: 'application/json; charset=UTF-8',
       'Content-Type': 'application/json; charset=UTF-8',
-      Authorization: this.authToken
+      Authorization: 'X-JMAP ' + this.authToken
     };
   }
 

--- a/lib/client/Client.js
+++ b/lib/client/Client.js
@@ -56,11 +56,13 @@ export default class Client {
    * The token will be exposed as the `authToken` property afterwards.
    *
    * @param token {String} The authentication token to use in JMAP requests.
+   * @param [scheme] {String} The authentication scheme according to RFC 7235
    *
    * @return {Client} This Client instance.
    */
-  withAuthenticationToken(token) {
+  withAuthenticationToken(token, scheme) {
     this.authToken = token;
+    this.authScheme = scheme;
 
     return this;
   }
@@ -107,6 +109,7 @@ export default class Client {
   withAuthAccess(access) {
     Utils.assertRequiredParameterHasType(access, 'access', AuthAccess);
 
+    this.authScheme = 'X-JMAP';
     this.authToken = access.accessToken;
     ['username', 'apiUrl', 'eventSourceUrl', 'uploadUrl', 'downloadUrl', 'versions', 'extensions'].forEach((property) => {
       this[property] = access[property];
@@ -650,7 +653,7 @@ export default class Client {
     return {
       Accept: 'application/json; charset=UTF-8',
       'Content-Type': 'application/json; charset=UTF-8',
-      Authorization: 'X-JMAP ' + this.authToken
+      Authorization: (this.authScheme ? this.authScheme + ' ' : '') + this.authToken
     };
   }
 

--- a/lib/models/AuthContinuation.js
+++ b/lib/models/AuthContinuation.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import Utils from '../utils/Utils.js';
+import AuthMethod from './AuthMethod';
 
 export default class AuthContinuation {
   /**
@@ -12,11 +13,56 @@ export default class AuthContinuation {
    */
   constructor(payload) {
     Utils.assertRequiredParameterIsPresent(payload, 'payload');
-    Utils.assertRequiredParameterIsPresent(payload.continuationToken, 'continuationToken');
+    Utils.assertRequiredParameterIsPresent(payload.loginId, 'loginId');
     Utils.assertRequiredParameterIsArrayWithMinimumLength(payload.methods, 'methods');
 
-    this.continuationToken = payload.continuationToken;
-    this.methods = payload.methods;
+    this.loginId = payload.loginId;
+    this.methods = payload.methods.map((method) => new AuthMethod(method));
     this.prompt = payload.prompt || null;
   }
+
+  /**
+   * Getter for the AuthMethod instance matching the given authentication type
+   *
+   * @param type {String} The authentication type
+   * @return {AuthMethod}
+   */
+  getMethod(type) {
+    Utils.assertRequiredParameterHasType(type, 'type', 'string');
+
+    let result = null;
+
+    this.methods.forEach((authMethod) => {
+      if (authMethod.type === type) {
+        result = authMethod;
+      }
+    });
+
+    if (!result) {
+      throw new Error('No AuthMethod of type "' + type + '" found');
+    }
+
+    return result;
+  }
+
+  /**
+   * Checks if the given authentication type is supported by one of the registred auth methods
+   *
+   * @param type {String} The authentication type to check
+   * @return {Boolean} True if supported, False otherwise
+   */
+  supports(type) {
+    Utils.assertRequiredParameterHasType(type, 'type', 'string');
+
+    let result = false;
+
+    try {
+      this.getMethod(type);
+      result = true;
+    } catch (e) {
+    }
+
+    return result;
+  }
+
 }

--- a/lib/models/AuthMethod.js
+++ b/lib/models/AuthMethod.js
@@ -15,6 +15,6 @@ export default class AuthMethod {
     Utils.assertRequiredParameterIsPresent(payload, 'payload');
     Utils.assertRequiredParameterHasType(payload.type, 'type', 'string');
 
-    this.type = payload.type;
+    Object.assign(this, payload);
   }
 }

--- a/lib/models/AuthMethod.js
+++ b/lib/models/AuthMethod.js
@@ -1,0 +1,20 @@
+'use strict';
+
+import Utils from '../utils/Utils.js';
+
+export default class AuthMethod {
+  /**
+   * This class represents a JMAP [AuthMethod]{@link http://jmap.io/spec.html#getting-an-access-token}.
+   *
+   * @constructor
+   *
+   * @param payload {Object} The server response of POST request to the authentication URL.
+   */
+
+  constructor(payload) {
+    Utils.assertRequiredParameterIsPresent(payload, 'payload');
+    Utils.assertRequiredParameterHasType(payload.type, 'type', 'string');
+
+    this.type = payload.type;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "lib/jmap-client.js",
   "devDependencies": {
     "babelify": "6.3.0",
+    "babel-plugin-object-assign": "1.2.1",
     "browserify-versionify": "1.0.6",
     "chai": "3.0.0",
     "chai-datetime": "1.4.0",

--- a/test/common/Client.js
+++ b/test/common/Client.js
@@ -94,6 +94,7 @@ describe('The Client class', function() {
       var client = defaultClient().withAuthAccess(authAccess);
 
       expect(client.authToken).to.equal(authAccess.accessToken);
+      expect(client.authScheme).to.equal('X-JMAP');
       ['username', 'versions', 'extensions', 'apiUrl', 'eventSourceUrl', 'uploadUrl', 'downloadUrl'].forEach(function(property) {
         expect(client[property]).to.equal(authAccess[property]);
       });
@@ -121,7 +122,7 @@ describe('The Client class', function() {
       new jmap.Client({
         post: function(url, headers) {
           expect(headers).to.deep.equal({
-            Authorization: 'X-JMAP token',
+            Authorization: 'token',
             'Content-Type': 'application/json; charset=UTF-8',
             Accept: 'application/json; charset=UTF-8'
           });
@@ -131,6 +132,50 @@ describe('The Client class', function() {
       })
         .withAPIUrl('https://test')
         .withAuthenticationToken('token')
+        .getAccounts()
+        .then(null, done);
+    });
+
+    it('should send correct HTTP headers with Authorization scheme', function(done) {
+      new jmap.Client({
+        post: function(url, headers) {
+          expect(headers).to.deep.equal({
+            Authorization: 'Bearer token',
+            'Content-Type': 'application/json; charset=UTF-8',
+            Accept: 'application/json; charset=UTF-8'
+          });
+
+          return q.reject();
+        }
+      })
+        .withAPIUrl('https://test')
+        .withAuthenticationToken('token', 'Bearer')
+        .getAccounts()
+        .then(null, done);
+    });
+
+    it('should send correct HTTP Authorization header after JMAP authentication', function(done) {
+      var authAccess = new jmap.AuthAccess({
+        username: 'user',
+        accessToken: 'accessToken1',
+        apiUrl: 'https://test',
+        eventSourceUrl: '/es',
+        uploadUrl: '/upload',
+        downloadUrl: '/download'
+      });
+
+      new jmap.Client({
+        post: function(url, headers) {
+          expect(headers).to.deep.equal({
+            Authorization: 'X-JMAP accessToken1',
+            'Content-Type': 'application/json; charset=UTF-8',
+            Accept: 'application/json; charset=UTF-8'
+          });
+
+          return q.reject();
+        }
+      })
+        .withAuthAccess(authAccess)
         .getAccounts()
         .then(null, done);
     });
@@ -218,7 +263,7 @@ describe('The Client class', function() {
       new jmap.Client({
         post: function(url, headers) {
           expect(headers).to.deep.equal({
-            Authorization: 'X-JMAP token',
+            Authorization: 'token',
             'Content-Type': 'application/json; charset=UTF-8',
             Accept: 'application/json; charset=UTF-8'
           });
@@ -315,7 +360,7 @@ describe('The Client class', function() {
       new jmap.Client({
         post: function(url, headers) {
           expect(headers).to.deep.equal({
-            Authorization: 'X-JMAP token',
+            Authorization: 'token',
             'Content-Type': 'application/json; charset=UTF-8',
             Accept: 'application/json; charset=UTF-8'
           });
@@ -747,7 +792,7 @@ describe('The Client class', function() {
       new jmap.Client({
         post: function(url, headers) {
           expect(headers).to.deep.equal({
-            Authorization: 'X-JMAP token',
+            Authorization: 'token',
             'Content-Type': 'application/json; charset=UTF-8',
             Accept: 'application/json; charset=UTF-8'
           });
@@ -978,7 +1023,7 @@ describe('The Client class', function() {
       new jmap.Client({
         post: function(url, headers) {
           expect(headers).to.deep.equal({
-            Authorization: 'X-JMAP token',
+            Authorization: 'token',
             'Content-Type': 'application/json; charset=UTF-8',
             Accept: 'application/json; charset=UTF-8'
           });
@@ -1127,7 +1172,7 @@ describe('The Client class', function() {
       new jmap.Client({
         post: function(url, headers) {
           expect(headers).to.deep.equal({
-            Authorization: 'X-JMAP token',
+            Authorization: 'token',
             'Content-Type': 'application/json; charset=UTF-8',
             Accept: 'application/json; charset=UTF-8'
           });
@@ -1278,7 +1323,7 @@ describe('The Client class', function() {
       new jmap.Client({
         post: function(url, headers) {
           expect(headers).to.deep.equal({
-            Authorization: 'X-JMAP token',
+            Authorization: 'token',
             'Content-Type': 'application/json; charset=UTF-8',
             Accept: 'application/json; charset=UTF-8'
           });

--- a/test/common/Client.js
+++ b/test/common/Client.js
@@ -121,7 +121,7 @@ describe('The Client class', function() {
       new jmap.Client({
         post: function(url, headers) {
           expect(headers).to.deep.equal({
-            Authorization: 'token',
+            Authorization: 'X-JMAP token',
             'Content-Type': 'application/json; charset=UTF-8',
             Accept: 'application/json; charset=UTF-8'
           });
@@ -218,7 +218,7 @@ describe('The Client class', function() {
       new jmap.Client({
         post: function(url, headers) {
           expect(headers).to.deep.equal({
-            Authorization: 'token',
+            Authorization: 'X-JMAP token',
             'Content-Type': 'application/json; charset=UTF-8',
             Accept: 'application/json; charset=UTF-8'
           });
@@ -315,7 +315,7 @@ describe('The Client class', function() {
       new jmap.Client({
         post: function(url, headers) {
           expect(headers).to.deep.equal({
-            Authorization: 'token',
+            Authorization: 'X-JMAP token',
             'Content-Type': 'application/json; charset=UTF-8',
             Accept: 'application/json; charset=UTF-8'
           });
@@ -747,7 +747,7 @@ describe('The Client class', function() {
       new jmap.Client({
         post: function(url, headers) {
           expect(headers).to.deep.equal({
-            Authorization: 'token',
+            Authorization: 'X-JMAP token',
             'Content-Type': 'application/json; charset=UTF-8',
             Accept: 'application/json; charset=UTF-8'
           });
@@ -978,7 +978,7 @@ describe('The Client class', function() {
       new jmap.Client({
         post: function(url, headers) {
           expect(headers).to.deep.equal({
-            Authorization: 'token',
+            Authorization: 'X-JMAP token',
             'Content-Type': 'application/json; charset=UTF-8',
             Accept: 'application/json; charset=UTF-8'
           });
@@ -1127,7 +1127,7 @@ describe('The Client class', function() {
       new jmap.Client({
         post: function(url, headers) {
           expect(headers).to.deep.equal({
-            Authorization: 'token',
+            Authorization: 'X-JMAP token',
             'Content-Type': 'application/json; charset=UTF-8',
             Accept: 'application/json; charset=UTF-8'
           });
@@ -1278,7 +1278,7 @@ describe('The Client class', function() {
       new jmap.Client({
         post: function(url, headers) {
           expect(headers).to.deep.equal({
-            Authorization: 'token',
+            Authorization: 'X-JMAP token',
             'Content-Type': 'application/json; charset=UTF-8',
             Accept: 'application/json; charset=UTF-8'
           });

--- a/test/common/Client.js
+++ b/test/common/Client.js
@@ -1684,15 +1684,15 @@ describe('The Client class', function() {
         post: function(url, headers, data) {
 
           return q({
-            continuationToken: 'continuationToken1',
-            methods: ['password', 'external']
+            loginId: 'loginId1',
+            methods: [{type:'password'}, {type:'external'}]
           });
         }
       })
       .withAuthenticationUrl('https://test')
       .authenticate('user@domain.com', 'Device name', function(authContinuation) {
-        expect(authContinuation.continuationToken).to.equal('continuationToken1');
-        expect(authContinuation.methods).to.deep.equal(['password', 'external']);
+        expect(authContinuation.loginId).to.equal('loginId1');
+        expect(authContinuation.methods.length).to.deep.equal(2);
         done();
 
         return q.reject();
@@ -1708,13 +1708,13 @@ describe('The Client class', function() {
             calls++;
 
             return q({
-              continuationToken: 'continuationToken1',
-              methods: ['password', 'external']
+              loginId: 'loginId1',
+              methods: [{type:'password'}, {type:'external'}]
             });
           } else {
-            expect(data.token).to.equal('continuationToken1');
-            expect(data.method).to.equal('password');
-            expect(data.password).to.equal('password1');
+            expect(data.loginId).to.equal('loginId1');
+            expect(data.type).to.equal('password');
+            expect(data.value).to.equal('password1');
             done();
 
             return q();
@@ -1724,8 +1724,8 @@ describe('The Client class', function() {
       .withAuthenticationUrl('https://test')
       .authenticate('user@domain.com', 'Device name', function(authContinuation) {
         return q({
-          method: 'password',
-          password: 'password1'
+          type: 'password',
+          value: 'password1'
         });
       });
     });
@@ -1734,14 +1734,14 @@ describe('The Client class', function() {
       new jmap.Client({
         post: function(url, headers, data) {
           return q({
-            continuationToken: 'continuationToken1',
-            methods: ['password']
+            loginId: 'loginId1',
+            methods: [{type:'password'}]
           });
         }
       })
       .withAuthenticationUrl('https://test')
       .authenticate('user@domain.com', 'Device name', function(authContinuation) {
-        return q({ method: 'external' });
+        return q({type: 'external'});
       })
       .then(null, function(err) {
         expect(err).to.be.instanceOf(Error);
@@ -1765,8 +1765,8 @@ describe('The Client class', function() {
         post: function(url, headers, data) {
           if (data.username) {
             return q({
-              continuationToken: 'continuationToken1',
-              methods: ['password', 'external']
+              loginId: 'loginId1',
+              methods: [{type:'password'}, {type:'external'}]
             });
           } else {
             return q(authAccessResponse);
@@ -1775,7 +1775,7 @@ describe('The Client class', function() {
       })
       .withAuthenticationUrl('https://test')
       .authenticate('user@domain.com', 'Device name', function(authContinuation) {
-        return q({ method: 'external' });
+        return q({type: 'external'});
       })
       .then(function(authAccess) {
         expect(authAccess).to.deep.equal(authAccessResponse);
@@ -1799,20 +1799,20 @@ describe('The Client class', function() {
         post: function(url, headers, data) {
           if (data.username) {
             return q({
-              continuationToken: 'continuationToken1',
-              methods: ['password']
+              loginId: 'loginId1',
+              methods: [{type:'password'}]
             });
-          } else if (data.password === 'pwd1') {
+          } else if (data.value === 'pwd1') {
             return q({
-              continuationToken: 'continuationToken2',
+              loginId: 'loginId2',
               prompt: '2nd Auth Factor',
-              methods: ['password']
+              methods: [{type:'totp'}]
             });
-          } else if (data.password === 'pwd2') {
+          } else if (data.value === 'pwd2') {
             return q({
-              continuationToken: 'continuationToken3',
+              loginId: 'loginId3',
               prompt: '3rd Auth Factor',
-              methods: ['password']
+              methods: [{type:'yubikeyotp'}]
             });
           } else {
             return q(authAccessResponse);
@@ -1821,12 +1821,12 @@ describe('The Client class', function() {
       })
       .withAuthenticationUrl('https://test')
       .authenticate('user@domain.com', 'Device name', function(authContinuation) {
-        if (authContinuation.continuationToken === 'continuationToken1') {
-          return q({ method: 'password', password: 'pwd1' });
-        } else if (authContinuation.continuationToken === 'continuationToken2') {
-          return q({ method: 'password', password: 'pwd2' });
+        if (authContinuation.loginId === 'loginId1') {
+          return q({type: 'password', value: 'pwd1'});
+        } else if (authContinuation.loginId === 'loginId2') {
+          return q({type: 'totp', value: 'pwd2'});
         } else {
-          return q({ method: 'password', password: 'pwd3' });
+          return q({type: 'yubikeyotp', value: 'pwd3'});
         }
       })
       .then(function(authAccess) {
@@ -1840,13 +1840,13 @@ describe('The Client class', function() {
         post: function(url, headers, data) {
           return q({
             accessToken: 'accessToken1',
-            continuationToken: 'continuationToken1'
+            loginId: 'loginId1'
           });
         }
       })
       .withAuthenticationUrl('https://test')
       .authenticate('user@domain.com', 'Device name', function(authContinuation) {
-        return q({ method: 'external' });
+        return q({type: 'external'});
       })
       .then(null, function(err) {
         expect(err).to.be.instanceOf(Error);
@@ -1859,8 +1859,8 @@ describe('The Client class', function() {
         post: function(url, headers, data) {
           if (data.username) {
             return q({
-              continuationToken: 'continuationToken1',
-              methods: ['external']
+              loginId: 'loginId1',
+              methods: [{type:'external'}]
             });
           } else {
             return q({
@@ -1886,8 +1886,8 @@ describe('The Client class', function() {
       new jmap.Client({
         post: function(url, headers, data) {
           return q({
-            continuationToken: 'continuationToken1',
-            methods: ['password']
+            loginId: 'loginId1',
+            methods: [{type:'password'}]
           });
         }
       })
@@ -1903,15 +1903,15 @@ describe('The Client class', function() {
       new jmap.Client({
         post: function(url, headers, data) {
           return q({
-            continuationToken: 'continuationToken1',
-            methods: ['password', 'external']
+            loginId: 'loginId1',
+            methods: [{type:'password'}, {type:'external'}]
           });
         }
       })
       .withAuthenticationUrl('https://test')
       .authExternal('user@domain.com', 'Device name', function(authContinuation) {
-        expect(authContinuation.continuationToken).to.equal('continuationToken1');
-        expect(authContinuation.methods).to.deep.equal(['password', 'external']);
+        expect(authContinuation.loginId).to.equal('loginId1');
+        expect(authContinuation.methods.length).to.equal(2);
         done();
 
         return q.reject();
@@ -1934,8 +1934,8 @@ describe('The Client class', function() {
         post: function(url, headers, data) {
           if (data.username) {
             return q({
-              continuationToken: 'continuationToken1',
-              methods: ['password', 'external']
+              loginId: 'loginId1',
+              methods: [{type:'password'}, {type:'external'}]
             });
           } else {
             return q(authAccessResponse);
@@ -1944,7 +1944,7 @@ describe('The Client class', function() {
       })
       .withAuthenticationUrl('https://test')
       .authExternal('user@domain.com', 'Device name', function(authContinuation) {
-        return q(authContinuation.continuationToken);
+        return q(authContinuation.loginId);
       })
       .then(function(authAccess) {
         expect(authAccess).to.deep.equal(authAccessResponse);
@@ -1961,8 +1961,8 @@ describe('The Client class', function() {
       new jmap.Client({
         post: function(url, headers, data) {
           return q({
-            continuationToken: 'continuationToken1',
-            methods: ['external']
+            loginId: 'loginId1',
+            methods: [{type:'external'}]
           });
         }
       }, promiseProvider)
@@ -1990,8 +1990,8 @@ describe('The Client class', function() {
         post: function(url, headers, data) {
           if (data.username) {
             return q({
-              continuationToken: 'continuationToken1',
-              methods: ['password', 'external']
+              loginId: 'loginId1',
+              methods: [{type:'password'}, {type:'external'}]
             });
           } else {
             return q(authAccessResponse);

--- a/test/common/models/Attachment.js
+++ b/test/common/models/Attachment.js
@@ -218,7 +218,7 @@ describe('The Attachment class', function() {
     it('should send an authenticated POST request to the downloadUrl, and reject on failure', function(done) {
       new jmap.Attachment(newClient(function(url, headers, data, raw) {
         expect(url).to.equal('downloadUrl/id1');
-        expect(headers.Authorization).to.equal('token');
+        expect(headers.Authorization).to.equal('X-JMAP token');
         expect(data).to.equal(null);
         expect(raw).to.equal(true);
 

--- a/test/common/models/Attachment.js
+++ b/test/common/models/Attachment.js
@@ -218,7 +218,7 @@ describe('The Attachment class', function() {
     it('should send an authenticated POST request to the downloadUrl, and reject on failure', function(done) {
       new jmap.Attachment(newClient(function(url, headers, data, raw) {
         expect(url).to.equal('downloadUrl/id1');
-        expect(headers.Authorization).to.equal('X-JMAP token');
+        expect(headers.Authorization).to.equal('token');
         expect(data).to.equal(null);
         expect(raw).to.equal(true);
 

--- a/test/common/models/AuthContinuation.js
+++ b/test/common/models/AuthContinuation.js
@@ -11,7 +11,7 @@ describe('The AuthContinuation class', function() {
       }).to.throw(Error);
     });
 
-    it('should throw if payload.continuationToken parameter is not defined', function() {
+    it('should throw if payload.loginId parameter is not defined', function() {
       expect(function() {
         var payload = {methods: []};
 
@@ -21,7 +21,7 @@ describe('The AuthContinuation class', function() {
 
     it('should throw if payload.methods parameter is not defined', function() {
       expect(function() {
-        var payload = {continuationToken: 'continuationToken1'};
+        var payload = {loginId: 'loginId1'};
 
         new jmap.AuthContinuation(payload);
       }).to.throw(Error);
@@ -29,19 +29,117 @@ describe('The AuthContinuation class', function() {
 
     it('should throw if payload.methods parameter is not an array', function() {
       expect(function() {
-        var payload = {continuationToken: 'continuationToken1', methods: 'password'};
+        var payload = {loginId: 'loginId1', methods: 'password'};
 
         new jmap.AuthContinuation(payload);
       }).to.throw(Error);
     });
 
-    it('should expose continuationToken and methods properties', function() {
-      var payload = {continuationToken: 'continuationToken1', methods: ['password', 'external']};
+    it('should throw if payload.methods parameter is not an array of objects', function() {
+      expect(function() {
+        var payload = {loginId: 'loginId1', methods: ['oauth','password']};
+
+        new jmap.AuthContinuation(payload);
+      }).to.throw(Error);
+    });
+
+    it('should expose loginId and methods properties', function() {
+      var payload = {
+        loginId: 'loginId1',
+        methods: [
+          {type: 'password'},
+          {type: 'external'}
+        ]
+      };
       var authContinuation = new jmap.AuthContinuation(payload);
 
-      expect(authContinuation.continuationToken).to.equal(payload.continuationToken);
+      expect(authContinuation.loginId).to.equal(payload.loginId);
       expect(authContinuation.methods).to.deep.equal(payload.methods);
     });
 
+  });
+
+  describe('The getMethod method', function() {
+    it('should throw if invalid type parameter is provided', function() {
+      expect(function() {
+        var payload = {
+          loginId: 'loginId1',
+          methods: [
+            {type: 'password'}
+          ]
+        };
+        var authContinuation = new jmap.AuthContinuation(payload);
+
+        authContinuation.getMethod(null);
+      }).to.throw(Error);
+    });
+
+    it('should throw if the given type is not supported', function() {
+      expect(function() {
+        var payload = {
+          loginId: 'loginId1',
+          methods: [
+            {type: 'password'}
+          ]
+        };
+        var authContinuation = new jmap.AuthContinuation(payload);
+
+        authContinuation.getMethod('oauth');
+      }).to.throw(Error);
+    });
+
+    it('should return an AuthMethod instance', function() {
+      var payload = {
+        loginId: 'loginId1',
+        methods: [
+          {type: 'external'},
+          {type: 'password'}
+        ]
+      };
+      var authContinuation = new jmap.AuthContinuation(payload);
+
+      expect(authContinuation.getMethod('password')).to.be.an.instanceof(jmap.AuthMethod);
+    });
+  });
+
+  describe('The supports method', function() {
+    it('should throw if invalid type parameter is provided', function() {
+      expect(function() {
+        var payload = {
+          loginId: 'loginId1',
+          methods: [
+            {type: 'password'}
+          ]
+        };
+        var authContinuation = new jmap.AuthContinuation(payload);
+
+        authContinuation.supports(null);
+      }).to.throw(Error);
+    });
+
+    it('should return true if type is supported', function() {
+      var payload = {
+        loginId: 'loginId1',
+        methods: [
+          {type: 'totp'},
+          {type: 'password'}
+        ]
+      };
+      var authContinuation = new jmap.AuthContinuation(payload);
+
+      expect(authContinuation.supports('password')).to.be.true;
+    });
+
+    it('should return false if type is not supported', function() {
+      var payload = {
+        loginId: 'loginId1',
+        methods: [
+          {type: 'password'}
+        ]
+      };
+      var authContinuation = new jmap.AuthContinuation(payload);
+
+      expect(authContinuation.supports('oauth')).to.be.false;
+    });
   });
 });

--- a/test/common/models/AuthMethod.js
+++ b/test/common/models/AuthMethod.js
@@ -33,5 +33,16 @@ describe('The AuthMethod class', function() {
 
       expect(authMethod.type).to.equal(payload.type);
     });
+
+    it('should expose all properties', function() {
+      var payload = {
+        type: 'u2f',
+        appId: 'app-id',
+        signChallenge: 'xyz'
+      };
+      var authMethod = new jmap.AuthMethod(payload);
+
+      expect(authMethod).to.deep.equal(payload);
+    });
   });
 });

--- a/test/common/models/AuthMethod.js
+++ b/test/common/models/AuthMethod.js
@@ -1,0 +1,37 @@
+'use strict';
+
+var expect = require('chai').expect,
+    jmap = require('../../../dist/jmap-client');
+
+describe('The AuthMethod class', function() {
+  describe('constructor', function() {
+    it('should throw if payload parameter is not defined', function() {
+      expect(function() {
+        new jmap.AuthMethod();
+      }).to.throw(Error);
+    });
+
+    it('should throw if payload.type parameter is not defined', function() {
+      expect(function() {
+        var payload = {};
+
+        new jmap.AuthMethod(payload);
+      }).to.throw(Error);
+    });
+
+    it('should throw if payload.type parameter is not a string', function() {
+      expect(function() {
+        var payload = {type: []};
+
+        new jmap.AuthMethod(payload);
+      }).to.throw(Error);
+    });
+
+    it('should expose the type property', function() {
+      var payload = {type: 'password'};
+      var authMethod = new jmap.AuthMethod(payload);
+
+      expect(authMethod.type).to.equal(payload.type);
+    });
+  });
+});


### PR DESCRIPTION
Refactored auth-related functions as per the latest JMAP spec updates

The two commits bring the client behavior in sync with the changes in the JMAP spec announced in the [JMAP forum](https://groups.google.com/forum/#!topic/jmap-discuss/mgXsDqzPR6Y) and requested in issue #44.
