### PR TITLE
add property blobId to Message. Fixes #65

### DIFF
--- a/lib/models/Message.js
+++ b/lib/models/Message.js
@@ -20,6 +20,7 @@ export default class Message extends Model {
    * @param threadId {String} The unique identifier of the _Thread_ this _Message_ is in.
    * @param mailboxIds {String[]} The array of _Mailbox_ identifiers this _Message_ is present into.
    * @param [opts] {Object} The optional properties of this _Message_.
+   * @param [opts.blobId=null] {String} The identifier  representing the raw [@!RFC5322] message.
    * @param [opts.inReplyToMessageId=null] {String} The id of the _Message_ this _Message_ is a reply to.
    * @param [opts.isUnread=false] {Boolean} Has the message not yet been read? This maps to the opposite of the \Seen flag in IMAP.
    * @param [opts.isFlagged=false] {Boolean} Is the message flagged? This maps to the \Flagged flag in IMAP.
@@ -56,6 +57,7 @@ export default class Message extends Model {
     this.id = id;
     this.threadId = threadId;
     this.mailboxIds = mailboxIds;
+    this.blobId = opts.blobId || null;
     this.inReplyToMessageId = opts.inReplyToMessageId || null;
     this.isUnread = opts.isUnread || false;
     this.isFlagged = opts.isFlagged || false;


### PR DESCRIPTION
When deserializing *Messages*, `blobId` property is set from provided JMAP response.