### PR TITLE
add required property 'blobId' to Message. Fixes #65

### DIFF
--- a/lib/models/Message.js
+++ b/lib/models/Message.js
@@ -17,6 +17,7 @@ export default class Message extends Model {
    *
    * @param jmap {Client} The {@link Client} instance that created this _Message_.
    * @param id {String} The unique identifier of this _Message_.
+   * @param blobId {String} The identifier  representing the raw [@!RFC5322] message.
    * @param threadId {String} The unique identifier of the _Thread_ this _Message_ is in.
    * @param mailboxIds {String[]} The array of _Mailbox_ identifiers this _Message_ is present into.
    * @param [opts] {Object} The optional properties of this _Message_.
@@ -44,16 +45,18 @@ export default class Message extends Model {
    * @see Model
    * @see EMailer
    */
-  constructor(jmap, id, threadId, mailboxIds, opts) {
+  constructor(jmap, id, blobId, threadId, mailboxIds, opts) {
     super(jmap);
 
     Utils.assertRequiredParameterIsPresent(id, 'id');
+    Utils.assertRequiredParameterIsPresent(blobId, 'blobId');
     Utils.assertRequiredParameterIsPresent(threadId, 'threadId');
     Utils.assertRequiredParameterIsArrayWithMinimumLength(mailboxIds, 'mailboxIds', 1);
 
     opts = opts || {};
 
     this.id = id;
+    this.blobId = blobId;
     this.threadId = threadId;
     this.mailboxIds = mailboxIds;
     this.inReplyToMessageId = opts.inReplyToMessageId || null;
@@ -181,6 +184,7 @@ export default class Message extends Model {
    * @param jmap {Client} The {@link Client} instance passed to the _Message_ constructor.
    * @param object {Object} The JSON representation of the _Message_, as a Javascript object.
    * @param object.id {Object} The identifier of the _Message_.
+   * @param object.blobId {String} The identifier  representing the raw [@!RFC5322] message.
    * @param object.threadId {String} The identifier of the thread the _Message_ is in.
    * @param object.mailboxIds {String[]} The array of _Mailbox_ identifiers the _Message_ is present into.
    *
@@ -189,6 +193,6 @@ export default class Message extends Model {
   static fromJSONObject(jmap, object) {
     Utils.assertRequiredParameterIsPresent(object, 'object');
 
-    return new Message(jmap, object.id, object.threadId, object.mailboxIds, object);
+    return new Message(jmap, object.id, object.blobId, object.threadId, object.mailboxIds, object);
   }
 }

--- a/test/common/Client.js
+++ b/test/common/Client.js
@@ -953,16 +953,19 @@ describe('The Client class', function() {
               state: 'm815034',
               list: [{
                 id: 'fm1u314',
+                blobId: '4f512aafed75e7fb',
                 threadId: '4f512aafed75e7fb',
                 mailboxIds: ['inbox']
               },
               {
                 id: 'fm1u312',
+                blobId: 'fed75e7fb4f512aa',
                 threadId: 'fed75e7fb4f512aa',
                 mailboxIds: ['inbox']
               },
               {
                 id: 'fm2u12',
+                blobId: 'fed75e7fb4f512aa',
                 threadId: 'fed75e7fb4f512aa',
                 mailboxIds: ['mailbox2']
               }
@@ -1000,9 +1003,9 @@ describe('The Client class', function() {
               new jmap.Thread(client, 'fed75e7fb4f512aa', { messageIds: ['fm1u312', 'fm2u12'] })
             ],
             [
-              new jmap.Message(client, 'fm1u314', '4f512aafed75e7fb', ['inbox']),
-              new jmap.Message(client, 'fm1u312', 'fed75e7fb4f512aa', ['inbox']),
-              new jmap.Message(client, 'fm2u12', 'fed75e7fb4f512aa', ['mailbox2'])
+              new jmap.Message(client, 'fm1u314', '4f512aafed75e7fb', '4f512aafed75e7fb', ['inbox']),
+              new jmap.Message(client, 'fm1u312', 'fed75e7fb4f512aa', 'fed75e7fb4f512aa', ['inbox']),
+              new jmap.Message(client, 'fm2u12', 'fed75e7fb4f512aa', 'fed75e7fb4f512aa', ['mailbox2'])
             ]
           ]);
 
@@ -1133,6 +1136,7 @@ describe('The Client class', function() {
               accountId: 'user@example.com',
               list: [{
                 id: 'fm1u314',
+                blobId: '4f512aafed75e7fb',
                 threadId: '4f512aafed75e7fb',
                 mailboxIds: ['inbox']
               }],
@@ -1152,7 +1156,7 @@ describe('The Client class', function() {
         .then(function(data) {
           expect(data).to.deep.equal([
             [new jmap.Thread(client, '4f512aafed75e7fb', { messageIds: ['fm1u314'] })],
-            [new jmap.Message(client, 'fm1u314', '4f512aafed75e7fb', ['inbox'])]
+            [new jmap.Message(client, 'fm1u314', '4f512aafed75e7fb', '4f512aafed75e7fb', ['inbox'])]
           ]);
 
           done();
@@ -1242,11 +1246,13 @@ describe('The Client class', function() {
             accountId: 'user@example.com',
             list: [{
               id: 'fm1u312',
+              blobId: 'fed75e7fb4f512aa',
               threadId: 'fed75e7fb4f512aa',
               mailboxIds: ['mailbox1']
             },
             {
               id: 'fm2u12',
+              blobId: 'fed75e7fb4f512aa',
               threadId: 'fed75e7fb4f512aa',
               mailboxIds: ['mailbox2']
             }],
@@ -1261,8 +1267,8 @@ describe('The Client class', function() {
         .getMessages({ ids: ['fm1u312', 'fm2u12'] })
         .then(function(data) {
           expect(data).to.deep.equal([
-            new jmap.Message(client, 'fm1u312', 'fed75e7fb4f512aa', ['mailbox1']),
-            new jmap.Message(client, 'fm2u12', 'fed75e7fb4f512aa', ['mailbox2'])
+            new jmap.Message(client, 'fm1u312', 'fed75e7fb4f512aa', 'fed75e7fb4f512aa', ['mailbox1']),
+            new jmap.Message(client, 'fm2u12', 'fed75e7fb4f512aa', 'fed75e7fb4f512aa', ['mailbox2'])
           ]);
 
           done();
@@ -1276,18 +1282,22 @@ describe('The Client class', function() {
             accountId: 'user@example.com',
             list: [{
               id: 'fm1u312',
+              blobId: 'fed75e7fb4f512aa',
               threadId: 'fed75e7fb4f512aa',
               mailboxIds: ['mailbox1']
             }, {
               id: 'fm1azf52',
+              blobId: 'fed75e7fb4f512aa',
               threadId: 'fed75e7fb4f512aa',
               mailboxIds: null
             }, {
               id: 'fm2u12',
+              blobId: 'fed75e7fb4f512aa',
               threadId: 'fed75e7fb4f512aa',
               mailboxIds: ['mailbox2']
             }, {
               id: 'fm1ab32',
+              blobId: 'fed75e7fb4f512aa',
               threadId: 'fed75e7fb4f512aa',
               mailboxIds: []
             }],
@@ -1302,8 +1312,8 @@ describe('The Client class', function() {
         .getMessages({ ids: ['fm1u312', 'fm2u12'] })
         .then(function(data) {
           expect(data).to.deep.equal([
-            new jmap.Message(client, 'fm1u312', 'fed75e7fb4f512aa', ['mailbox1']),
-            new jmap.Message(client, 'fm2u12', 'fed75e7fb4f512aa', ['mailbox2'])
+            new jmap.Message(client, 'fm1u312', 'fed75e7fb4f512aa', 'fed75e7fb4f512aa', ['mailbox1']),
+            new jmap.Message(client, 'fm2u12', 'fed75e7fb4f512aa', 'fed75e7fb4f512aa', ['mailbox2'])
           ]);
 
           done();

--- a/test/common/models/Message.js
+++ b/test/common/models/Message.js
@@ -16,32 +16,38 @@ describe('The Message class', function() {
       }).to.throw(Error);
     });
 
-    it('should throw an Error if threadId is not defined', function() {
+    it('should throw an Error if blobId is not defined', function() {
       expect(function() {
         new jmap.Message({}, 'id');
-      }).to.throw(Error);
+      }).to.throw(Error, 'blobId');
+    });
+
+    it('should throw an Error if threadId is not defined', function() {
+      expect(function() {
+        new jmap.Message({}, 'id', 'blobId');
+      }).to.throw(Error, 'threadId');
     });
 
     it('should throw an Error if mailboxIds is not defined', function() {
       expect(function() {
-        new jmap.Message({}, 'id', 'threadId');
-      }).to.throw(Error);
+        new jmap.Message({}, 'id', 'blobId', 'threadId');
+      }).to.throw(Error, 'mailboxIds');
     });
 
     it('should throw an Error if mailboxIds is not an array', function() {
       expect(function() {
-        new jmap.Message({}, 'id', 'threadId', 'mailboxId');
-      }).to.throw(Error);
+        new jmap.Message({}, 'id', 'blobId', 'threadId', 'mailboxId');
+      }).to.throw(Error, 'mailboxIds');
     });
 
     it('should throw an Error if mailboxIds is zero-length', function() {
       expect(function() {
-        new jmap.Message({}, 'id', 'threadId', []);
-      }).to.throw(Error);
+        new jmap.Message({}, 'id', 'blobId', 'threadId', []);
+      }).to.throw(Error, 'mailboxIds');
     });
 
     it('should use default values for all other fields if not defined', function() {
-      var message = new jmap.Message({}, 'id', 'threadId', ['inbox']);
+      var message = new jmap.Message({}, 'id', 'blobId', 'threadId', ['inbox']);
 
       expect(message.inReplyToMessageId).to.equal(null);
       expect(message.isUnread).to.equal(false);
@@ -64,7 +70,7 @@ describe('The Message class', function() {
     });
 
     it('should use default values for all other fields if an empty opts object is given', function() {
-      var message = new jmap.Message({}, 'id', 'threadId', ['inbox'], {});
+      var message = new jmap.Message({}, 'id', 'blobId', 'threadId', ['inbox'], {});
 
       expect(message.inReplyToMessageId).to.equal(null);
       expect(message.isUnread).to.equal(false);
@@ -87,7 +93,7 @@ describe('The Message class', function() {
     });
 
     it('should allow defining optional properties through the opts object', function() {
-      var message = new jmap.Message({}, 'id', 'threadId', ['inbox'], {
+      var message = new jmap.Message({}, 'id', 'blobId', 'threadId', ['inbox'], {
         from: [{
           name: '',
           email: 'me@open-paas.org'
@@ -103,11 +109,11 @@ describe('The Message class', function() {
     });
 
     it('should set From to the unknown EMailer when not defined', function() {
-      expect(new jmap.Message({}, 'id', 'threadId', ['inbox']).from).to.deep.equal(jmap.EMailer.unknown());
+      expect(new jmap.Message({}, 'id', 'blobId', 'threadId', ['inbox']).from).to.deep.equal(jmap.EMailer.unknown());
     });
 
     it('should take the first item of the From option', function() {
-      var message = new jmap.Message({}, 'id', 'threadId', ['inbox'], {
+      var message = new jmap.Message({}, 'id', 'blobId', 'threadId', ['inbox'], {
         from: [{
           name: '',
           email: 'me@open-paas.org'
@@ -124,7 +130,7 @@ describe('The Message class', function() {
     });
 
     it('should support a single EMailer in the From option', function() {
-      var message = new jmap.Message({}, 'id', 'threadId', ['inbox'], {
+      var message = new jmap.Message({}, 'id', 'blobId', 'threadId', ['inbox'], {
         from: {
           name: 'notanarray',
           email: 'notanarray@open-paas.org'
@@ -138,7 +144,7 @@ describe('The Message class', function() {
     });
 
     it('should create EMailer instances for the To option', function() {
-      var message = new jmap.Message({}, 'id', 'threadId', ['inbox'], {
+      var message = new jmap.Message({}, 'id', 'blobId', 'threadId', ['inbox'], {
         to: [{
           name: '',
           email: 'me@open-paas.org'
@@ -155,7 +161,7 @@ describe('The Message class', function() {
     });
 
     it('should create EMailer instances for the CC option', function() {
-      var message = new jmap.Message({}, 'id', 'threadId', ['inbox'], {
+      var message = new jmap.Message({}, 'id', 'blobId', 'threadId', ['inbox'], {
         cc: [{
           name: '',
           email: 'me@open-paas.org'
@@ -172,7 +178,7 @@ describe('The Message class', function() {
     });
 
     it('should create EMailer instances for the BCC option', function() {
-      var message = new jmap.Message({}, 'id', 'threadId', ['inbox'], {
+      var message = new jmap.Message({}, 'id', 'blobId', 'threadId', ['inbox'], {
         bcc: [{
           name: '',
           email: 'me@open-paas.org'
@@ -189,7 +195,7 @@ describe('The Message class', function() {
     });
 
     it('should parse the message date as a Date object', function() {
-      var message = new jmap.Message({}, 'id', 'threadId', ['inbox'], {
+      var message = new jmap.Message({}, 'id', 'blobId', 'threadId', ['inbox'], {
         date: '2015-09-23T12:34:56Z'
       });
 
@@ -197,7 +203,7 @@ describe('The Message class', function() {
     });
 
     it('should set attachments to an empty array if message has no attachments', function() {
-      expect(new jmap.Message({}, 'id', 'threadId', ['inbox'], {}).attachments).to.deep.equal([]);
+      expect(new jmap.Message({}, 'id', 'blobId', 'threadId', ['inbox'], {}).attachments).to.deep.equal([]);
     });
 
     it('should set attachments to an array of Attachment objects if message has attachments', function() {
@@ -205,7 +211,7 @@ describe('The Message class', function() {
         downloadUrl: 'https://jmap.org/dl/{blobId}'
       };
 
-      expect(new jmap.Message(client, 'id', 'threadId', ['inbox'], {
+      expect(new jmap.Message(client, 'id', 'blobId', 'threadId', ['inbox'], {
         attachments: [{
           blobId: '1234'
         }, {
@@ -258,13 +264,14 @@ describe('The Message class', function() {
     });
 
     it('should return an instance of Message', function() {
-      expect(jmap.Message.fromJSONObject({}, { id: 'id', threadId: 'threadId', mailboxIds: ['mailboxId'] })).to.be.an.instanceof(jmap.Message);
+      expect(jmap.Message.fromJSONObject({}, { id: 'id', blobId: 'blobId', threadId: 'threadId', mailboxIds: ['mailboxId'] })).to.be.an.instanceof(jmap.Message);
     });
 
     it('should copy values for all other fields if defined', function() {
       var message = jmap.Message.fromJSONObject({}, {
         id: 'fm2u12',
         inReplyToMessageId: 'fm2u11',
+        blobId: 'fed75e7fb4f512aa',
         threadId: 'fed75e7fb4f512aa',
         mailboxIds: ['mailbox2'],
         isUnread: true,
@@ -329,7 +336,7 @@ describe('The Message class', function() {
 
           done();
         }
-      }, 'id', 'threadId', ['inbox']).move(['mailbox1', 'mailbox2']);
+      }, 'id', 'blobId', 'threadId', ['inbox']).move(['mailbox1', 'mailbox2']);
     });
 
   });
@@ -344,7 +351,7 @@ describe('The Message class', function() {
 
           done();
         }
-      }, 'id', 'threadId', ['inbox']).update({ property: 'property' });
+      }, 'id', 'blobId', 'threadId', ['inbox']).update({ property: 'property' });
     });
   });
 
@@ -367,7 +374,7 @@ describe('The Message class', function() {
     });
 
     it('should delegate to message.update, passing the required option', function(done) {
-      var message = new jmap.Message({}, 'id', 'threadId', ['inbox']);
+      var message = new jmap.Message({}, 'id', 'blobId', 'threadId', ['inbox']);
 
       message.update = function(option) {
         expect(option).to.deep.equal({ isFlagged: true });
@@ -396,7 +403,7 @@ describe('The Message class', function() {
     });
 
     it('should delegate to message.update, passing the required option', function(done) {
-      var message = new jmap.Message({}, 'id', 'threadId', ['inbox']);
+      var message = new jmap.Message({}, 'id', 'blobId', 'threadId', ['inbox']);
 
       message.update = function(option) {
         expect(option).to.deep.equal({ isUnread: true });
@@ -425,7 +432,7 @@ describe('The Message class', function() {
     });
 
     it('should delegate to message.update, passing the required option', function(done) {
-      var message = new jmap.Message({}, 'id', 'threadId', ['inbox']);
+      var message = new jmap.Message({}, 'id', 'blobId', 'threadId', ['inbox']);
 
       message.update = function(option) {
         expect(option).to.deep.equal({ isAnswered: true });
@@ -444,7 +451,7 @@ describe('The Message class', function() {
 
           done();
         }
-      }, 'id', 'threadId', ['inbox']).destroy();
+      }, 'id', 'blobId', 'threadId', ['inbox']).destroy();
     });
 
   });
@@ -456,7 +463,7 @@ describe('The Message class', function() {
         getMailboxWithRole: function() {
           return q.reject();
         }
-      }, 'id', 'threadId', ['inbox']).moveToMailboxWithRole(jmap.MailboxRole.TRASH).then(null, done);
+      }, 'id', 'blobId', 'threadId', ['inbox']).moveToMailboxWithRole(jmap.MailboxRole.TRASH).then(null, done);
     });
 
     it('should support a String argument, when it maps to a JMAP role', function(done) {
@@ -464,18 +471,18 @@ describe('The Message class', function() {
         getMailboxWithRole: function() {
           return q.reject();
         }
-      }, 'id', 'threadId', ['inbox']).moveToMailboxWithRole('inbox').then(null, done);
+      }, 'id', 'blobId', 'threadId', ['inbox']).moveToMailboxWithRole('inbox').then(null, done);
     });
 
     it('should throw an Error if the role is UNKNOWN', function() {
       expect(function() {
-        new jmap.Message(new jmap.Client({}), 'id', 'threadId', ['inbox']).moveToMailboxWithRole(jmap.MailboxRole.UNKNOWN);
+        new jmap.Message(new jmap.Client({}), 'id', 'blobId', 'threadId', ['inbox']).moveToMailboxWithRole(jmap.MailboxRole.UNKNOWN);
       }).to.throw(Error);
     });
 
     it('should throw an Error if the role is an unknown String', function() {
       expect(function() {
-        new jmap.Message(new jmap.Client({}), 'id', 'threadId', ['inbox']).moveToMailboxWithRole('test');
+        new jmap.Message(new jmap.Client({}), 'id', 'blobId', 'threadId', ['inbox']).moveToMailboxWithRole('test');
       }).to.throw(Error);
     });
 
@@ -489,7 +496,7 @@ describe('The Message class', function() {
 
           done();
         }
-      }, 'id', 'threadId', ['inbox']).moveToMailboxWithRole('inbox');
+      }, 'id', 'blobId', 'threadId', ['inbox']).moveToMailboxWithRole('inbox');
     });
 
     it('should reject the promise if the mailbox does not exist', function(done) {
@@ -497,7 +504,7 @@ describe('The Message class', function() {
         getMailboxWithRole: function() {
           return q.reject('Does not exist !');
         }
-      }, 'id', 'threadId', ['inbox'])
+      }, 'id', 'blobId', 'threadId', ['inbox'])
         .moveToMailboxWithRole('inbox')
         .then(null, function() {
           done();


### PR DESCRIPTION
`blobId` is now required when creating a Message. When deserializing Messages from json, `blobId` property is set from provided JMAP response, or fail if missing.

Fixes https://github.com/linagora/jmap-client/issues/65