### PR TITLE
Fix 'main' property in package.json to enable loading with npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.26-dev",
   "repository": "linagora/jmap-client",
   "description": "This lib help to make requests against a JMAP server",
-  "main": "lib/jmap-client.js",
+  "main": "dist/jmap-client.js",
   "devDependencies": {
     "babel-plugin-add-module-exports": "0.2.1",
     "babel-plugin-transform-builtin-extend": "1.1.0",


### PR DESCRIPTION
Background: I'm linking the jmap-client package into an email client project using `npm link`. This requires the `main` property to point to a valid file and there's no such file as `lib/jmap-client.js`.